### PR TITLE
A very basic FlowStorm setup

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -47,20 +47,23 @@
               ;; For tracing panama calls.
               #_"-Djextract.trace.downcalls=true"]}
 
-  :storm {:classpath-overrides {org.clojure/clojure nil}
-          :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.0-9"}
-                       com.github.flow-storm/flow-storm-dbg {:mvn/version "4.2.2"}}
-          :jvm-opts ["-Dflowstorm.theme=dark"
-                     "-Dflowstorm.callTreeUpdate=false"
-                     "-Dflowstorm.autoUpdateUI=false"
-                     "-Dclojure.storm.instrumentAutoPrefixes=false"
+  :runtime-storm {:classpath-overrides {org.clojure/clojure nil}
+                  :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.0-9"}
+                               com.github.flow-storm/flow-storm-inst {:mvn/version "4.2.2"}}
+                  :jvm-opts ["-Dclojure.storm.instrumentAutoPrefixes=false"
 
-                     ;; Instrumentation
-                     ;; Only games
-                     "-Dclojure.storm.instrumentOnlyPrefixes=minimal,leo,noel"
+                             ;; Instrumentation
+                             ;; Only games
+                             "-Dclojure.storm.instrumentOnlyPrefixes=minimal,leo,noel"
 
-                     ;; games + vybe
-                     #_"-Dclojure.storm.instrumentOnlyPrefixes=vybe.,minimal,leo,noel"
-                     #_"-Dclojure.storm.instrumentSkipPrefixes=vybe.flecs,vybe.panama"]}}
+                             ;; games + vybe
+                             #_"-Dclojure.storm.instrumentOnlyPrefixes=vybe.,minimal,leo,noel"
+                             #_"-Dclojure.storm.instrumentSkipPrefixes=vybe.flecs,vybe.panama"]}
+  :ui-storm {:extra-deps {com.github.flow-storm/flow-storm-dbg {:mvn/version "4.2.2"}}
+             :exec-fn flow-storm.debugger.main/start-debugger
+             :exec-args {:port 7888}
+             :jvm-opts ["-Dflowstorm.theme=dark"
+                        "-Dflowstorm.callTreeUpdate=false"
+                        "-Dflowstorm.autoUpdateUI=false"]}}
 
  :paths ["src" "resources" "vybe_native"]}

--- a/deps.edn
+++ b/deps.edn
@@ -45,6 +45,22 @@
               "-Djava.library.path=vybe_native"
 
               ;; For tracing panama calls.
-              #_"-Djextract.trace.downcalls=true"]}}
+              #_"-Djextract.trace.downcalls=true"]}
+
+  :storm {:classpath-overrides {org.clojure/clojure nil}
+          :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.0-9"}
+                       com.github.flow-storm/flow-storm-dbg {:mvn/version "4.2.2"}}
+          :jvm-opts ["-Dflowstorm.theme=dark"
+                     "-Dflowstorm.callTreeUpdate=false"
+                     "-Dflowstorm.autoUpdateUI=false"
+                     "-Dclojure.storm.instrumentAutoPrefixes=false"
+
+                     ;; Instrumentation
+                     ;; Only games
+                     "-Dclojure.storm.instrumentOnlyPrefixes=minimal,leo,noel"
+
+                     ;; games + vybe
+                     #_"-Dclojure.storm.instrumentOnlyPrefixes=vybe.,minimal,leo,noel"
+                     #_"-Dclojure.storm.instrumentSkipPrefixes=vybe.flecs,vybe.panama"]}}
 
  :paths ["src" "resources" "vybe_native"]}

--- a/src/fs.clj
+++ b/src/fs.clj
@@ -1,0 +1,22 @@
+(ns fs
+  (:require [vybe.flecs]
+            [vybe.panama])
+  (:import [vybe.flecs VybeFlecsWorldMap]
+           [vybe.panama VybePMap]))
+
+
+(extend-protocol flow-storm.runtime.values/SnapshotP
+  VybeFlecsWorldMap
+  (snapshot-value [^VybeFlecsWorldMap wm]
+    (persistent!
+     (reduce-kv (fn [acc eid e]
+                  (if (seq e)
+                    (assoc! acc eid e )
+                    acc))
+                (transient {})
+                wm))))
+
+(extend-protocol flow-storm.runtime.values/SnapshotP
+  VybePMap
+  (snapshot-value [^VybePMap vpm]
+    (into {} vpm)))

--- a/src/leo.clj
+++ b/src/leo.clj
@@ -16,6 +16,7 @@
    [vybe.network :as vn]
    #_[vybe.audio :as va]
    [vybe.math :as vm]
+   [fs]
    #_[overtone.core :refer :all])
   (:import
    (org.vybe.flecs flecs)

--- a/src/noel.clj
+++ b/src/noel.clj
@@ -9,7 +9,9 @@
    [vybe.c :as vc]
    [vybe.math :as vm]
    [vybe.jolt :as vj]
-   [vybe.jolt.c :as vj.c])
+   [vybe.jolt.c :as vj.c]
+   [fs]
+   [flow-storm.runtime.debuggers-api :refer [set-recording]])
   (:import
    (org.vybe.raylib raylib)))
 
@@ -162,6 +164,9 @@
         (assoc w (vf/path [:my/model :vg.gltf/Camera.001]) [:vg/camera-active])
         (assoc w (vf/path [:my/model :vg.gltf/Camera]) [:vg/camera-active]))))
 
+  (when (vg/key-pressed? :r) (set-recording true))
+  (when (vg/key-pressed? :g) (set-recording false))
+
   (vg/default-systems w)
   ;; Progress the systems (using Flecs).
   (vf/progress w delta-time)
@@ -190,6 +195,8 @@
         switch? (and raycasted (vr.c/is-mouse-button-released (raylib/MOUSE_BUTTON_LEFT)))
         tv (w (vf/path [:my/model :vg.gltf/office :vg.gltf/tv]))
         _ (when switch?
+            (debugger)
+
             (if (::turned-off tv)
               (disj tv ::turned-off)
               (conj tv ::turned-off)))


### PR DESCRIPTION
This is not for merge, just sharing the experiment!

Have been playing a little bit with debugging vybe-games or vybe itself with FlowStorm.

Apart from the setup alias there is a fs.clj that snapshots VybeFlecsWorldMap and VybePMap, it could be interesting to snapshot the rest of the interesting mutable objects. 

The experiments I tried :

- Start as always but with the storm alias `clj -M:linux-basic:runtime-storm -m vybe.raylib`
- Connect another repl (like cider)
- Run the init (tried noel and leo)
- On a different terminal run FlowStorm UI `clj -X:ui-storm`
- In my old box the FPS of instrumented code still runs at 60fps (while not recording)
- On leo, just hit recording for some frames and then stop
- On noel, since it grabs your mouse, I added a couple of keys to control FS, `r` start recording, `g` to stop.
- What I have tried on noel is to add a `(debugger)` statement on the tv switch just to go there faster, I then hit `r` and switch on or off the tv, then start hitting `g` like there is no tomorrow to stop recording. I guess because FPS drop while recording it also misses some events, not sure.

I'm running with auto update ui in false, and the tree disabled, to get some extra perf, so after recording has stopped click the red arrow to update the UI manually.

Curious how it runs on a more powerful box. 